### PR TITLE
Refine base ESLint config, add Prettier to CI lint job

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -19,7 +19,10 @@ jobs:
           node-version: 15.x
 
       - name: Install dependencies
-        run: yarn
+        run: yarn --frozen-lockfile
+
+      - name: Check formatting
+        run: yarn format:check
 
       - name: Run ESLint
         run: yarn lint

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+site/.next/

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "build": "yarn --cwd site next build",
     "start": "yarn --cwd site next start",
     "storybook": "yarn --cwd site storybook",
-    "lint": "yarn --cwd site lint"
+    "lint": "yarn --cwd site lint",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "devDependencies": {
     "prettier": "^2.2.1",

--- a/scripts/eslint/base.js
+++ b/scripts/eslint/base.js
@@ -4,24 +4,30 @@ module.exports = {
   parserOptions: {
     project: './tsconfig.json',
   },
-  extends: [
-    'eslint:recommended',
-    'prettier',
-    'plugin:prettier/recommended',
-    'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended',
+  extends: ['eslint:recommended'],
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      extends: [
+        'plugin:@typescript-eslint/eslint-recommended',
+        'plugin:@typescript-eslint/recommended',
+      ],
+      rules: {
+        // Allow use of `@ts-ignore` comments
+        '@typescript-eslint/ban-ts-ignore': 'off',
+
+        // Allow return types to be inferred
+        '@typescript-eslint/explicit-function-return-type': 'off',
+
+        // Allow implicit types at module boundaries
+        '@typescript-eslint/explicit-module-boundary-types': 'off',
+
+        // Disallow unhandled promises, requiring `void` statement
+        '@typescript-eslint/no-floating-promises': [
+          'error',
+          { ignoreVoid: true },
+        ],
+      },
+    },
   ],
-  rules: {
-    // Allow use of `@ts-ignore` comments
-    '@typescript-eslint/ban-ts-ignore': 'off',
-
-    // Allow return types to be inferred
-    '@typescript-eslint/explicit-function-return-type': 'off',
-
-    // Allow implicit types at module boundaries
-    '@typescript-eslint/explicit-module-boundary-types': 'off',
-
-    // Disallow unhandled promises, requiring `void` statement
-    '@typescript-eslint/no-floating-promises': ['error', { ignoreVoid: true }],
-  },
 };

--- a/scripts/eslint/package.json
+++ b/scripts/eslint/package.json
@@ -9,16 +9,12 @@
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",
     "eslint": "^7.22.0",
-    "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",
-    "eslint-plugin-react-hooks": "^4.2.0",
-    "prettier": "^2.2.1"
+    "eslint-plugin-react-hooks": "^4.2.0"
   },
   "devDependencies": {
     "@types/eslint": "^7.2.7",
-    "@types/prettier": "^2.2.3",
     "typescript": "^4.2.3"
   },
   "eslintConfig": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2092,11 +2092,6 @@
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-5.0.3.tgz#e7b5aebbac150f8b5fdd4a46e7f0bd8e65e19109"
   integrity sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
 
-"@types/prettier@^2.2.3":
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.2.3.tgz#ef65165aea2924c9359205bf748865b8881753c0"
-  integrity sha512-PijRCG/K3s3w1We6ynUKdxEc5AcuuH3NBmMDP8uvKVp6X43UY7NQlTzczakXP3DJR0F4dfNQIGjU2cUeRYs2AA==
-
 "@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
@@ -4668,11 +4663,6 @@ escodegen@^1.12.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz#4ef1eaf97afe5176e6a75ddfb57c335121abc5a6"
-  integrity sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==
-
 eslint-plugin-jsx-a11y@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz#a2d84caa49756942f42f1ffab9002436391718fd"
@@ -4689,13 +4679,6 @@ eslint-plugin-jsx-a11y@^6.4.1:
     has "^1.0.3"
     jsx-ast-utils "^3.1.0"
     language-tags "^1.0.5"
-
-eslint-plugin-prettier@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz#7079cfa2497078905011e6f82e8dd8453d1371b7"
-  integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-react-hooks@^4.2.0:
   version "4.2.0"
@@ -4970,11 +4953,6 @@ fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.2.6:
   version "2.2.7"
@@ -7946,13 +7924,6 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 prettier-plugin-organize-imports@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
This improves ESLint behaviour in the project:

- Remove Prettier ESLint rules in favour of standalone `prettier` – this removes noisy warnings in-editor. Equivalent formatting checks are added to the CI `lint` job.
- Scope `@typescript-eslint` rules within `scripts/eslint/base.js` to `.ts` and `.tsx` files only – this fixes handling of `.js` files such as `next.config.js`.
- Add root `tsconfig.json` for monorepo setup.