### PR TITLE
Add Layout and Header components, add dark mode toggle

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -22,7 +22,8 @@
     "notion-utils": "^4.3.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",
-    "react-notion-x": "^4.3.3"
+    "react-notion-x": "^4.3.3",
+    "use-dark-mode": "^2.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",

--- a/site/src/components/Header.module.css
+++ b/site/src/components/Header.module.css
@@ -1,0 +1,40 @@
+.header {
+  position: fixed;
+  display: flex;
+  top: 0;
+  right: 0;
+  left: 0;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 22px;
+  background-color: var(--color-header);
+}
+
+@media (min-width: 480px) {
+  .header {
+    padding: 25px 30px;
+  }
+}
+
+.title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.button {
+  display: flex;
+  padding: 2px;
+  border: 0;
+  background: none;
+  cursor: pointer;
+}
+
+.title:hover,
+.button:hover {
+  opacity: 0.8;
+}
+
+.icon {
+  fill: var(--color-text-primary);
+}

--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -1,0 +1,44 @@
+import styles from './Header.module.css';
+
+/**
+ * SVG source from ionic-team/ionicons:
+ * https://github.com/ionic-team/ionicons/blob/b74a92328c5229315b9c621159f84713e178661e/src/svg/contrast-sharp.svg
+ *
+ * Copyright (c) 2015-present Ionic (http://ionic.io/)
+ * Licensed under MIT
+ */
+const AppearanceIcon = () => (
+  <svg
+    className={styles.icon}
+    xmlns="http://www.w3.org/2000/svg"
+    width="20px"
+    height="20px"
+    viewBox="0 0 512 512"
+  >
+    <path d="M256 32C132.29 32 32 132.29 32 256s100.29 224 224 224 224-100.29 224-224S379.71 32 256 32zM128.72 383.28A180 180 0 01256 76v360a178.82 178.82 0 01-127.28-52.72z" />
+  </svg>
+);
+
+type Props = {
+  title: string;
+  darkMode: boolean;
+  onDarkModeChange: (darkMode: boolean) => void;
+};
+
+const Header = ({ title, darkMode, onDarkModeChange }: Props) => (
+  <header className={styles.header}>
+    <a className={styles.title} href="/">
+      {title}
+    </a>
+    <button
+      className={styles.button}
+      type="button"
+      title="Tap to change light/dark appearance"
+      onClick={() => onDarkModeChange(!darkMode)}
+    >
+      <AppearanceIcon />
+    </button>
+  </header>
+);
+
+export default Header;

--- a/site/src/components/Layout.module.css
+++ b/site/src/components/Layout.module.css
@@ -1,0 +1,3 @@
+.content {
+  margin-top: 140px;
+}

--- a/site/src/components/Layout.tsx
+++ b/site/src/components/Layout.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+import useDarkMode from 'use-dark-mode';
+import Header from './Header';
+import styles from './Layout.module.css';
+
+type Props = {
+  children: ReactNode;
+};
+
+/**
+ * The root layout component for all pages.
+ */
+const Layout = ({ children }: Props) => {
+  const darkMode = useDarkMode();
+
+  return (
+    <>
+      <Header
+        title="Alex Hunt"
+        darkMode={darkMode.value}
+        onDarkModeChange={darkMode.toggle}
+      />
+      <div className={styles.content}>{children}</div>
+    </>
+  );
+};
+
+export default Layout;

--- a/site/src/pages/_app.tsx
+++ b/site/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import type { AppProps } from 'next/app';
+import Head from 'next/head';
 
 // organize-imports-ignore
 import '~styles/globals.css';
@@ -6,7 +7,18 @@ import 'react-notion-x/src/styles.css';
 import '~notion/style-overrides.css';
 
 const App = ({ Component, pageProps }: AppProps) => {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Head>
+        <link rel="preconnect" href="https://fonts.gstatic.com" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+        />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
 };
 
 export default App;

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -1,7 +1,9 @@
 import type { GetStaticProps } from 'next';
+import Head from 'next/head';
 import { NotionAPI } from 'notion-client';
 import type { ExtendedRecordMap } from 'notion-types';
 import { NotionRenderer } from 'react-notion-x';
+import Layout from '~components/Layout';
 
 const BIO_PAGE_ID = '3c84a17f3b1347c1ac8677d7b0037b43';
 
@@ -16,8 +18,19 @@ export const getStaticProps: GetStaticProps = async () => {
   };
 };
 
-const Home = ({ bio }: { bio: ExtendedRecordMap }) => {
-  return <NotionRenderer recordMap={bio} />;
+type Props = {
+  bio: ExtendedRecordMap;
 };
+
+const Home = ({ bio }: Props) => (
+  <>
+    <Head>
+      <title>Alex Hunt – Software developer &amp; occasional writer</title>
+    </Head>
+    <Layout>
+      <NotionRenderer recordMap={bio} />
+    </Layout>
+  </>
+);
 
 export default Home;

--- a/site/src/styles/globals.css
+++ b/site/src/styles/globals.css
@@ -2,8 +2,7 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
-    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  font-family: 'Inter', -apple-system, sans-serif;
 }
 
 a {
@@ -13,4 +12,20 @@ a {
 
 * {
   box-sizing: border-box;
+}
+
+:root {
+  --color-background: #fff;
+  --color-header: rgba(255, 255, 255, 0.9);
+  --color-text-primary: #37352f;
+}
+
+.dark-mode {
+  --color-background: #222;
+  --color-header: rgba(34, 34, 34, 0.9);
+  --color-text-primary: #eee;
+}
+
+body {
+  background-color: var(--color-background);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -498,6 +498,11 @@
     "@typescript-eslint/types" "4.18.0"
     eslint-visitor-keys "^2.0.0"
 
+"@use-it/event-listener@^0.1.2":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@use-it/event-listener/-/event-listener-0.1.6.tgz#5776274fec72f3f25af9ead1898e7f45bc435812"
+  integrity sha512-e6V7vbU8xpuqy4GZkTLExHffOFgxmGHo3kNWnlhzM/zcX2v+idbD/HaJ9sKdQMgTh+L7MIhdRDXGX3SdAViZzA==
+
 "@xobotyi/scrollbar-width@1.9.5":
   version "1.9.5"
   resolved "https://registry.yarnpkg.com/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz#80224a6919272f405b87913ca13b92929bdf3c4d"
@@ -3720,6 +3725,21 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-dark-mode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/use-dark-mode/-/use-dark-mode-2.3.1.tgz#d506349c7b7e09e9977cb8a6ab4470896aa3779a"
+  integrity sha512-hmcdJR96tTustRQdaQwe6jMrZHnmPqXBxgy4jaQ4gsfhwajsCpjECuq9prgDe9XxMx/f9r96o2/md6O4Lwhwjg==
+  dependencies:
+    "@use-it/event-listener" "^0.1.2"
+    use-persisted-state "^0.3.0"
+
+use-persisted-state@^0.3.0:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/use-persisted-state/-/use-persisted-state-0.3.3.tgz#5e0f2236967cec7c34de33abc07ae6818e7c7451"
+  integrity sha512-pCNlvYC8+XjRxwnIut4teGC9f2p9aD88R8OGseQGZa2dvqG/h1vEGk1vRE1IZG0Vf161UDpn+NlW4+UGubQflQ==
+  dependencies:
+    "@use-it/event-listener" "^0.1.2"
 
 use-subscription@1.5.1:
   version "1.5.1"


### PR DESCRIPTION
- Add page layout and site header components.
- Include a dark mode toggle button in the header, setting up a base light/dark appearance in the global stylesheet. Implement toggle using [use-dark-mode](https://www.npmjs.com/package/use-dark-mode) (which will read the system default and write any preference change to LocalStorage).
- Set primary typeface to Inter.

For now, all styling uses built-in Next.js CSS module support.

| Light | Dark |
| - | - |
| ![image](https://user-images.githubusercontent.com/2547783/111522511-4d5de800-8752-11eb-930d-d961e2eb2f93.png) | ![image](https://user-images.githubusercontent.com/2547783/111522503-4a62f780-8752-11eb-86d1-c849498e58bf.png) |
