### PR TITLE
Set up page generation for Notes articles

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -7,7 +7,7 @@
 .vercel
 
 # Build output
-/build
+/.cache
 
 # Cache and log files
 npm-debug.log*

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -3,4 +3,13 @@ module.exports = {
     locales: ['en-GB'],
     defaultLocale: 'en-GB',
   },
+  async redirects() {
+    return [
+      {
+        source: '/notes',
+        destination: '/',
+        permanent: false,
+      },
+    ];
+  },
 };

--- a/site/package.json
+++ b/site/package.json
@@ -14,9 +14,12 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "clear-cache": "rm -rf .cache/",
     "lint": "eslint src/ --ext=.ts,.tsx"
   },
   "dependencies": {
+    "flat-cache": "^3.0.4",
+    "invariant": "^2.2.4",
     "next": "10.0.8",
     "notion-client": "^4.3.2",
     "notion-utils": "^4.3.0",
@@ -27,6 +30,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",
+    "@types/flat-cache": "^2.0.0",
+    "@types/invariant": "^2.2.34",
     "@types/node": "^14.14.35",
     "@types/react": "^17.0.3",
     "babel-loader": "^8.2.2",

--- a/site/src/notion/getNotesPageMapping.ts
+++ b/site/src/notion/getNotesPageMapping.ts
@@ -1,0 +1,70 @@
+import flatCache from 'flat-cache';
+import invariant from 'invariant';
+import { NotionAPI } from 'notion-client';
+import getPageProperties from './getPageProperties';
+
+const NOTES_COLLECTION_ID = '5beb2c5f-74e4-463c-8cf5-b08b5d3a02aa';
+const NOTES_DATE_DESC_VIEW_ID = '3e0c5db2-e077-4479-81b7-ac99e25e29e1';
+
+export type NotesPageMap = {
+  [path: string]: {
+    id: string;
+    title: string;
+    date: string;
+  };
+};
+
+/**
+ * Get the mapping of complete site paths to page metadata for all published
+ * pages in the 'Notes' collection. On first run, results are persisted in the
+ * `.cache` directory unless `clearCache` is set.
+ */
+const getNotesPageMapping = async (
+  clearCache = false
+): Promise<NotesPageMap> => {
+  if (clearCache) {
+    flatCache.clearAll();
+  }
+
+  const cache = flatCache.load('notes', '.cache');
+
+  if (Object.keys(cache.all()).length === 0) {
+    const notion = new NotionAPI();
+    const collection = await notion.getCollectionData(
+      NOTES_COLLECTION_ID,
+      NOTES_DATE_DESC_VIEW_ID
+    );
+
+    for (const id of collection.result.blockIds) {
+      const {
+        Name: title,
+        Slug: slug,
+        Published: published,
+        Date: date,
+      } = getPageProperties(collection, id);
+
+      invariant(
+        typeof slug === 'string',
+        'Expected page to have a Slug property'
+      );
+      invariant(
+        typeof published === 'boolean',
+        'Expected page to have a Published property'
+      );
+      invariant(
+        typeof date === 'string',
+        'Expected page to have a Date property'
+      );
+
+      if (published) {
+        cache.setKey('/notes/' + slug, { id, title, date });
+      }
+    }
+
+    cache.save();
+  }
+
+  return cache.all();
+};
+
+export default getNotesPageMapping;

--- a/site/src/notion/getPageProperties.ts
+++ b/site/src/notion/getPageProperties.ts
@@ -1,0 +1,50 @@
+import invariant from 'invariant';
+import type { CollectionInstance } from 'notion-types';
+
+type BasePageProps = {
+  Name: string;
+  [key: string]: unknown;
+};
+
+/**
+ * Get the parsed properties for a page within a collection response. Handles a
+ * minimal subset of Notion property types.
+ */
+const getPageProperties = (
+  collection: CollectionInstance,
+  pageId: string
+): BasePageProps => {
+  const collectionId = Object.keys(collection.recordMap.collection)[0];
+  const schema = collection.recordMap.collection[collectionId].value.schema;
+
+  const page = collection.recordMap.block[pageId];
+  const props: { [key: string]: unknown } = {};
+
+  for (const [key, prop] of Object.entries(page.value.properties)) {
+    const { type, name } = schema[key];
+    const value = prop[0];
+
+    switch (type) {
+      case 'checkbox':
+        props[name] = value[0] === 'Yes';
+        break;
+      case 'date':
+        props[name] = value[1][0][1].start_date;
+        break;
+      default:
+        if (typeof value[0] === 'string') {
+          props[name] = value[0];
+        }
+        break;
+    }
+  }
+
+  invariant(
+    typeof props.Name === 'string',
+    'Expected page to have a Name property'
+  );
+
+  return props as BasePageProps;
+};
+
+export default getPageProperties;

--- a/site/src/pages/notes/[slug].tsx
+++ b/site/src/pages/notes/[slug].tsx
@@ -1,0 +1,50 @@
+import type { GetStaticPaths, GetStaticProps } from 'next';
+import Head from 'next/head';
+import { NotionAPI } from 'notion-client';
+import type { ExtendedRecordMap } from 'notion-types';
+import { NotionRenderer } from 'react-notion-x';
+import Layout from '~components/Layout';
+import getNotesPageMapping from '~notion/getNotesPageMapping';
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const pages = await getNotesPageMapping();
+
+  return {
+    paths: Object.keys(pages),
+    fallback: false,
+  };
+};
+
+export const getStaticProps: GetStaticProps = async context => {
+  const { slug } = context.params;
+  const notion = new NotionAPI();
+
+  const pages = await getNotesPageMapping();
+  const { id, title } = pages['/notes/' + slug];
+
+  return {
+    props: {
+      title,
+      recordMap: await notion.getPage(id),
+    },
+    revalidate: 10,
+  };
+};
+
+type Props = {
+  title: string;
+  recordMap: ExtendedRecordMap;
+};
+
+const NotePage = ({ title, recordMap }: Props) => (
+  <>
+    <Head>
+      <title>{title} | Alex Hunt</title>
+    </Head>
+    <Layout>
+      <NotionRenderer recordMap={recordMap} />
+    </Layout>
+  </>
+);
+
+export default NotePage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -375,10 +375,20 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.46.tgz#0fb6bfbbeabd7a30880504993369c4bf1deab1fe"
   integrity sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
 
+"@types/flat-cache@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/flat-cache/-/flat-cache-2.0.0.tgz#64e5d3b426c392b603a208a55bdcc7d920ce6e57"
+  integrity sha512-fHeEsm9hvmZ+QHpw6Fkvf19KIhuqnYLU6vtWLjd5BsMd/qVi7iTkMioDZl0mQmfNRA1A6NwvhrSRNr9hGYZGww==
+
 "@types/http-cache-semantics@*":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz#9140779736aa2655635ee756e2467d787cfe8a2a"
   integrity sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==
+
+"@types/invariant@^2.2.34":
+  version "2.2.34"
+  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.34.tgz#05e4f79f465c2007884374d4795452f995720bbe"
+  integrity sha512-lYUtmJ9BqUN688fGY1U1HZoWT1/Jrmgigx2loq4ZcJpICECm/Om3V314BxdzypO0u5PORKGMM6x0OXaljV1YFg==
 
 "@types/js-cookie@2.2.6":
   version "2.2.6"


### PR DESCRIPTION
Set up page generation for blog (will be called "Notes"). Due to separate execution of Next's `getStaticPaths` and `getStaticProps`, this uses a file cache storing a path (including slug) → ID + metadata mapping.

![image](https://user-images.githubusercontent.com/2547783/111901488-74593a00-8a30-11eb-9b9b-5bc23e9be72e.png)
