### PR TITLE
Add Notion styles and code block syntax highlighting, add responsive layout container

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -23,6 +23,8 @@
     "next": "10.0.8",
     "notion-client": "^4.3.2",
     "notion-utils": "^4.3.0",
+    "prism-themes": "^1.6.0",
+    "prismjs": "^1.23.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-notion": "^0.9.3",

--- a/site/src/components/Container.module.css
+++ b/site/src/components/Container.module.css
@@ -1,0 +1,20 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+  padding: 0 var(--space-page-margin-xs);
+}
+
+@media (--breakpoint-sm) {
+  .container {
+    padding: 0 var(--space-page-margin-sm);
+    max-width: 580px;
+  }
+}
+
+@media (--breakpoint-md) {
+  .container {
+    padding: 0;
+    max-width: 700px;
+  }
+}

--- a/site/src/components/Container.tsx
+++ b/site/src/components/Container.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+import styles from './Container.module.css';
+
+type Props = {
+  children: ReactNode;
+};
+
+/**
+ * A layout container that horizontally bounds content within a page.
+ */
+const Container = ({ children }: Props) => (
+  <div className={styles.container}>{children}</div>
+);
+
+export default Container;

--- a/site/src/components/Header.module.css
+++ b/site/src/components/Header.module.css
@@ -6,13 +6,14 @@
   left: 0;
   align-items: center;
   justify-content: space-between;
-  padding: 20px 22px;
+  padding: 20px var(--space-page-margin-xs);
   background-color: var(--color-header);
+  z-index: 100;
 }
 
 @media (--breakpoint-sm) {
   .header {
-    padding: 25px 30px;
+    padding: 25px var(--space-page-margin-sm);
   }
 }
 

--- a/site/src/pages/_app.tsx
+++ b/site/src/pages/_app.tsx
@@ -5,6 +5,17 @@ import Head from 'next/head';
 import '~styles/theme.css';
 import '~styles/globals.css';
 import 'react-notion/src/styles.css';
+import '~styles/notion.css';
+import '~styles/prism-gruvbox-dark.css';
+
+// organize-imports-ignore
+import 'prismjs';
+import 'prismjs/components/prism-markup-templating';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-php';
+import 'prismjs/components/prism-python';
 
 const App = ({ Component, pageProps }: AppProps) => {
   return (
@@ -13,7 +24,11 @@ const App = ({ Component, pageProps }: AppProps) => {
         <link rel="preconnect" href="https://fonts.gstatic.com" />
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+        />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,700;1,400&display=swap"
         />
       </Head>
       <Component {...pageProps} />

--- a/site/src/pages/notes/[slug].tsx
+++ b/site/src/pages/notes/[slug].tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import { NotionAPI } from 'notion-client';
 import type { BlockMapType } from 'react-notion';
 import { NotionRenderer } from 'react-notion';
+import Container from '~components/Container';
 import Layout from '~components/Layout';
 import getNotesPageMapping from '~notion/getNotesPageMapping';
 
@@ -42,7 +43,12 @@ const NotePage = ({ title, blockMap }: Props) => (
       <title>{title} | Alex Hunt</title>
     </Head>
     <Layout>
-      <NotionRenderer blockMap={blockMap} />
+      <article>
+        <Container>
+          <NotionRenderer blockMap={blockMap} />
+          <a href="/">Back to Notes</a>
+        </Container>
+      </article>
     </Layout>
   </>
 );

--- a/site/src/styles/breakpoints.ts
+++ b/site/src/styles/breakpoints.ts
@@ -3,6 +3,7 @@
  */
 export const breakpoints = {
   sm: 480,
+  md: 768,
 };
 
 /**

--- a/site/src/styles/globals.css
+++ b/site/src/styles/globals.css
@@ -2,7 +2,7 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family: 'Inter', -apple-system, sans-serif;
+  font-family: var(--font-family-display);
 }
 
 a {

--- a/site/src/styles/notion.css
+++ b/site/src/styles/notion.css
@@ -1,0 +1,67 @@
+.notion {
+  color: var(--color-text-primary);
+}
+
+@media (--breakpoint-sm) {
+  .notion {
+    font-size: 1.125rem;
+  }
+}
+
+.notion-h1,
+.notion-h2,
+.notion-h3 {
+  font-family: var(--font-family-display);
+  line-height: 1.6;
+}
+
+.notion-h2 {
+  margin-top: 1.5em;
+}
+
+.notion-h3 {
+  margin-top: 2em;
+}
+
+.notion-text,
+.notion-list,
+.notion-quote {
+  font-family: var(--font-family-body);
+}
+
+.notion-text {
+  margin: 1em 0;
+  line-height: 1.8;
+}
+
+.notion-quote {
+  margin: 1em 0;
+  font-family: var(--font-family-body);
+  font-style: italic;
+  font-size: 140%;
+}
+
+.notion-callout {
+  margin: 1em 0;
+}
+
+.notion-callout-text {
+  font-family: var(--font-family-body);
+  font-size: 110%;
+  font-style: italic;
+  line-height: 1.6;
+}
+
+.notion-callout > div:first-child {
+  display: none;
+}
+
+.notion-code {
+  margin: 2em 0;
+  padding: 1.75em 1.5em;
+  font-size: 80% !important;
+}
+
+.notion-inline-code {
+  color: var(--color-inline-code);
+}

--- a/site/src/styles/prism-gruvbox-dark.css
+++ b/site/src/styles/prism-gruvbox-dark.css
@@ -1,0 +1,111 @@
+/**
+ * Gruvbox dark theme (https://github.com/morhetz/gruvbox)
+ *
+ * Adapted from:
+ * https://github.com/PrismJS/prism-themes/blob/295bc134135c37d802b6d545dd95a6e8dde40600/themes/prism-gruvbox-dark.css
+ *
+ * Copyright (c) 2015 PrismJS
+ * Licensed under MIT
+ */
+
+code[class*='language-'],
+pre[class*='language-'] {
+  color: var(--color-gruvbox-light1);
+  font-family: Consolas, Monaco, 'Andale Mono', monospace;
+  direction: ltr;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  line-height: 1.5;
+  tab-size: 4;
+  hyphens: none;
+}
+
+pre[class*='language-'] {
+  overflow: auto;
+}
+
+:not(pre) > code[class*='language-'],
+pre[class*='language-'] {
+  background: var(--color-gruvbox-dark0-soft);
+}
+
+.token.comment,
+.token.prolog,
+.token.cdata {
+  color: var(--color-gruvbox-light4);
+}
+
+.token.delimiter,
+.token.boolean,
+.token.keyword,
+.token.selector,
+.token.important,
+.token.atrule {
+  color: var(--color-gruvbox-bright-red);
+}
+
+.token.operator,
+.token.punctuation,
+.token.attr-name {
+  color: var(--color-gruvbox-light4);
+}
+
+.token.tag,
+.token.tag .punctuation,
+.token.doctype,
+.token.builtin {
+  color: var(--color-gruvbox-bright-yellow);
+}
+
+.token.entity,
+.token.number,
+.token.symbol {
+  color: var(--color-gruvbox-bright-purple);
+}
+
+.token.property,
+.token.constant,
+.token.variable {
+  color: var(--color-gruvbox-bright-red);
+}
+
+.token.string,
+.token.char {
+  color: var(--color-gruvbox-bright-green);
+}
+
+.token.attr-value,
+.token.attr-value .punctuation {
+  color: var(--color-gruvbox-light4);
+}
+
+.token.url {
+  color: var(--color-gruvbox-bright-green);
+  text-decoration: underline;
+}
+
+.token.function {
+  color: var(--color-gruvbox-bright-yellow);
+}
+
+.token.regex {
+  background: var(--color-gruvbox-bright-green);
+}
+
+.token.bold {
+  font-weight: bold;
+}
+
+.token.italic {
+  font-style: italic;
+}
+
+.token.inserted {
+  background: var(--color-gruvbox-light4);
+}
+
+.token.deleted {
+  background: var(--color-gruvbox-bright-red);
+}

--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -1,11 +1,35 @@
 :root {
-  --color-background: #fff;
+  /* Typography */
+  --font-family-display: Inter, -apple-system, sans-serif;
+  --font-family-body: Lora, -apple-system, sans-serif;
+
+  /* Layout */
+  --space-page-margin-xs: 22px;
+  --space-page-margin-sm: 30px;
+
+  /* Gruvbox palette (https://github.com/morhetz/gruvbox) */
+  --color-gruvbox-dark0-soft: #32302f;
+  --color-gruvbox-light1: #ebdbb2;
+  --color-gruvbox-light4: #a89984;
+  --color-gruvbox-bright-red: #fb4934;
+  --color-gruvbox-bright-green: #b8bb26;
+  --color-gruvbox-bright-yellow: #fabd2f;
+  --color-gruvbox-bright-purple: #d3869b;
+  --color-gruvbox-bright-aqua: #8ec07c;
+
+  /* Colours */
+  --color-background: white;
   --color-header: rgba(255, 255, 255, 0.95);
   --color-text-primary: #37352f;
+  --color-text-secondary: #b3b3b3;
+  --color-inline-code: var(--color-gruvbox-bright-red);
 }
 
 .dark-mode {
+  /* Colours */
   --color-background: #222;
   --color-header: rgba(34, 34, 34, 0.95);
   --color-text-primary: #eee;
+  --color-text-secondary: #eee;
+  --color-inline-code: var(--color-gruvbox-bright-aqua);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3102,7 +3102,12 @@ prettier@^2.2.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
   integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
-prismjs@^1.21.0:
+prism-themes@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/prism-themes/-/prism-themes-1.6.0.tgz#3bdb4f0780588a4abd770f70537e5cc4898198d1"
+  integrity sha512-L7pbxbUvFj8bVIWpcHCwDFOykhozk6Dja9sxqdcFCWwUI77tSFsWE7imf9OQQAmezLNLaBxRlXNcD2k0VCE/0w==
+
+prismjs@^1.21.0, prismjs@^1.23.0:
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
   integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==


### PR DESCRIPTION
Reintroduce a `notion.css` stylesheet to customise react-notion styles and configure a customised Gruvbox Prism.js theme for syntax highlighting in code blocks. This also adds the `Container` component and builds out `theme.css` a little more.

Body text now uses the Lora typeface. Very happy with the overall presentation for content blocks 🙂.

| Light appearance | Dark appearance |
| - | - |
| ![image](https://user-images.githubusercontent.com/2547783/112753413-72aee980-8fcf-11eb-8b51-80b9d204422b.png) | ![image](https://user-images.githubusercontent.com/2547783/112753415-76427080-8fcf-11eb-93a2-0bc55fcd5908.png) |