### PR TITLE
Add Hero and ArticleHeader components, remove leading spacing from Layout

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint src/ --ext=.ts,.tsx"
   },
   "dependencies": {
+    "date-fns": "^2.19.0",
     "flat-cache": "^3.0.4",
     "invariant": "^2.2.4",
     "next": "10.0.8",

--- a/site/src/components/ArticleHeader.module.css
+++ b/site/src/components/ArticleHeader.module.css
@@ -1,0 +1,23 @@
+.root {
+  margin-top: 40px;
+  margin-bottom: 40px;
+}
+
+.title {
+  font-size: 2.25rem;
+  color: var(--color-text-primary);
+}
+
+@media (--breakpoint-sm) {
+  .title {
+    font-size: 3rem;
+  }
+}
+
+.meta {
+  color: var(--color-text-primary);
+}
+
+.date {
+  color: var(--color-text-secondary);
+}

--- a/site/src/components/ArticleHeader.tsx
+++ b/site/src/components/ArticleHeader.tsx
@@ -1,0 +1,20 @@
+import { format, formatRFC3339, parseISO } from 'date-fns';
+import styles from './ArticleHeader.module.css';
+
+type Props = {
+  title: string;
+  date: string;
+};
+
+const ArticleHeader = ({ title, date }: Props) => (
+  <div className={styles.root}>
+    <h1 className={styles.title}>{title}</h1>
+    <div className={styles.meta}>
+      <time className={styles.date} dateTime={formatRFC3339(parseISO(date))}>
+        {format(parseISO(date), 'd MMMM Y')}
+      </time>
+    </div>
+  </div>
+);
+
+export default ArticleHeader;

--- a/site/src/components/Header.module.css
+++ b/site/src/components/Header.module.css
@@ -1,3 +1,13 @@
+.root {
+  padding-bottom: 64px;
+}
+
+@media (--breakpoint-sm) {
+  .root {
+    padding-bottom: 74px;
+  }
+}
+
 .header {
   position: fixed;
   display: flex;
@@ -6,6 +16,8 @@
   left: 0;
   align-items: center;
   justify-content: space-between;
+  max-width: 1500px;
+  margin: 0 auto;
   padding: 20px var(--space-page-margin-xs);
   background-color: var(--color-header);
   z-index: 100;
@@ -14,6 +26,12 @@
 @media (--breakpoint-sm) {
   .header {
     padding: 25px var(--space-page-margin-sm);
+  }
+}
+
+@media (min-width: 1080px) {
+  .header {
+    background-color: unset;
   }
 }
 

--- a/site/src/components/Header.tsx
+++ b/site/src/components/Header.tsx
@@ -26,19 +26,21 @@ type Props = {
 };
 
 const Header = ({ title, darkMode, onDarkModeChange }: Props) => (
-  <header className={styles.header}>
-    <a className={styles.title} href="/">
-      {title}
-    </a>
-    <button
-      className={styles.button}
-      type="button"
-      title="Tap to change light/dark appearance"
-      onClick={() => onDarkModeChange(!darkMode)}
-    >
-      <AppearanceIcon />
-    </button>
-  </header>
+  <div className={styles.root}>
+    <header className={styles.header}>
+      <a className={styles.title} href="/">
+        {title}
+      </a>
+      <button
+        className={styles.button}
+        type="button"
+        title="Tap to change light/dark appearance"
+        onClick={() => onDarkModeChange(!darkMode)}
+      >
+        <AppearanceIcon />
+      </button>
+    </header>
+  </div>
 );
 
 export default Header;

--- a/site/src/components/Hero.module.css
+++ b/site/src/components/Hero.module.css
@@ -1,0 +1,9 @@
+.hero {
+  margin: 40px 0;
+}
+
+@media (--breakpoint-sm) {
+  .hero {
+    margin: 70px 0;
+  }
+}

--- a/site/src/components/Hero.tsx
+++ b/site/src/components/Hero.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+import Container from './Container';
+import styles from './Hero.module.css';
+
+type Props = {
+  children: ReactNode;
+};
+
+const Hero = ({ children }: Props) => (
+  <div className={styles.hero}>
+    <Container>{children}</Container>
+  </div>
+);
+
+export default Hero;

--- a/site/src/components/Layout.module.css
+++ b/site/src/components/Layout.module.css
@@ -1,3 +1,0 @@
-.content {
-  margin-top: 140px;
-}

--- a/site/src/components/Layout.tsx
+++ b/site/src/components/Layout.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react';
 import useDarkMode from 'use-dark-mode';
 import Header from './Header';
-import styles from './Layout.module.css';
 
 type Props = {
   children: ReactNode;
@@ -20,7 +19,7 @@ const Layout = ({ children }: Props) => {
         darkMode={darkMode.value}
         onDarkModeChange={darkMode.toggle}
       />
-      <div className={styles.content}>{children}</div>
+      {children}
     </>
   );
 };

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 import { NotionAPI } from 'notion-client';
 import type { BlockMapType } from 'react-notion';
 import { NotionRenderer } from 'react-notion';
+import Hero from '~components/Hero';
 import Layout from '~components/Layout';
 
 const BIO_PAGE_ID = '3c84a17f3b1347c1ac8677d7b0037b43';
@@ -28,7 +29,9 @@ const Home = ({ bio }: Props) => (
       <title>Alex Hunt – Software developer &amp; occasional writer</title>
     </Head>
     <Layout>
-      <NotionRenderer blockMap={bio} />
+      <Hero>
+        <NotionRenderer blockMap={bio} />
+      </Hero>
     </Layout>
   </>
 );

--- a/site/src/pages/notes/[slug].tsx
+++ b/site/src/pages/notes/[slug].tsx
@@ -3,12 +3,14 @@ import Head from 'next/head';
 import { NotionAPI } from 'notion-client';
 import type { BlockMapType } from 'react-notion';
 import { NotionRenderer } from 'react-notion';
+import ArticleHeader from '~components/ArticleHeader';
 import Container from '~components/Container';
 import Layout from '~components/Layout';
 import getNotesPageMapping from '~notion/getNotesPageMapping';
 
 type Props = {
   title: string;
+  date: string;
   blockMap: BlockMapType;
 };
 
@@ -26,18 +28,19 @@ export const getStaticProps: GetStaticProps<Props> = async context => {
   const notion = new NotionAPI();
 
   const pages = await getNotesPageMapping();
-  const { id, title } = pages['/notes/' + slug];
+  const { id, title, date } = pages['/notes/' + slug];
 
   return {
     props: {
       title,
+      date,
       blockMap: (await notion.getPage(id)).block as BlockMapType,
     },
     revalidate: 10,
   };
 };
 
-const NotePage = ({ title, blockMap }: Props) => (
+const NotePage = ({ title, date, blockMap }: Props) => (
   <>
     <Head>
       <title>{title} | Alex Hunt</title>
@@ -45,6 +48,7 @@ const NotePage = ({ title, blockMap }: Props) => (
     <Layout>
       <article>
         <Container>
+          <ArticleHeader title={title} date={date} />
           <NotionRenderer blockMap={blockMap} />
           <a href="/">Back to Notes</a>
         </Container>

--- a/site/src/styles/globals.css
+++ b/site/src/styles/globals.css
@@ -16,4 +16,5 @@ a {
 
 body {
   background-color: var(--color-background);
+  color: var(--color-text-primary);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1192,6 +1192,11 @@ data-uri-to-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz#594b8973938c5bc2c33046535785341abc4f3636"
   integrity sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==
 
+date-fns@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.19.0.tgz#65193348635a28d5d916c43ec7ce6fbd145059e1"
+  integrity sha512-X3bf2iTPgCAQp9wvjOQytnf5vO5rESYRXlPIVcgSbtT5OTScPcsf9eZU+B/YIkKAtYr5WeCii58BgATrNitlWg==
+
 debug@2:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
- Add `Hero` component for unique hero styling on homepage.
- Add and populate `ArticleHeader` component for individual note articles.
- Remove top margin from `Layout`, update `Header` to reserve necessary space for itself.
