### PR TITLE
Add verify-lockfile CI check

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,6 +7,20 @@ on:
     branches: [master]
 
 jobs:
+  verify-lockfile:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 15.x
+
+      - name: Verify if dependencies match yarn.lock
+        run: yarn check --integrity
+
   lint:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
New CI job to prevent merging code in a state where yarn.lock doesn't satisfy required dependencies – sometimes missed when splitting commits.