### PR TITLE
Add local fetching/hosting of image assets from Notion content

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -8,6 +8,8 @@
 
 # Build output
 /.cache
+/public/static/
+!/public/static/.gitkeep
 
 # Cache and log files
 npm-debug.log*

--- a/site/package.json
+++ b/site/package.json
@@ -10,6 +10,9 @@
     "url": "https://github.com/huntie/alexhunt.io",
     "directory": "site"
   },
+  "engines": {
+    "node": "^15.12.0"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -38,6 +41,7 @@
     "@types/invariant": "^2.2.34",
     "@types/node": "^14.14.35",
     "@types/react": "^17.0.3",
+    "@types/react-dom": "^17.0.3",
     "babel-loader": "^8.2.2",
     "eslint": "^7.22.0",
     "postcss-custom-media": "^8.0.0",

--- a/site/src/components/NotionRenderer.tsx
+++ b/site/src/components/NotionRenderer.tsx
@@ -1,0 +1,14 @@
+import type { ComponentProps } from 'react';
+import { NotionRenderer as BaseNotionRenderer } from 'react-notion';
+
+const mapImageUrl = (url: string) => {
+  const imagePath = url.split('amazonaws.com/secure.notion-static.com/')[1];
+
+  return `/static/${imagePath.substring(0, 36)}.${imagePath.split('.')[1]}`;
+};
+
+const NotionRenderer = (props: ComponentProps<typeof BaseNotionRenderer>) => (
+  <BaseNotionRenderer {...props} mapImageUrl={mapImageUrl} />
+);
+
+export default NotionRenderer;

--- a/site/src/notion/fetchAndCacheImages.ts
+++ b/site/src/notion/fetchAndCacheImages.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import https from 'https';
+import invariant from 'invariant';
+import path from 'path';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import type { BlockMapType } from 'react-notion';
+import { defaultMapImageUrl, NotionRenderer } from 'react-notion';
+
+const STATIC_DIR = './public/static';
+
+const getLocalFileName = (url: string) => {
+  const imagePath = url.split('amazonaws.com/secure.notion-static.com/')[1];
+
+  invariant(
+    typeof imagePath === 'string',
+    'Image URL did not match expected format'
+  );
+
+  return imagePath.substring(0, 36) + path.extname(imagePath);
+};
+
+const downloadImage = async (url: string, localPath: string) => {
+  await new Promise((resolve, reject) => {
+    const file = fs.createWriteStream(localPath);
+
+    https.get(url, response => {
+      return response.pipe(file).on('finish', resolve).on('error', reject);
+    });
+  });
+};
+
+/**
+ * Fetch and store all image files locally on this server/CDN for each Notion
+ * image block.
+ */
+const fetchAndCacheImages = async (blockMap: BlockMapType) => {
+  const existingImages = new Set(await fs.promises.readdir(STATIC_DIR));
+  const imagesToFetch: string[] = [];
+  const downloadUrls: string[] = [];
+
+  ReactDOMServer.renderToString(
+    React.createElement(NotionRenderer, {
+      blockMap,
+      mapImageUrl: (url, block) => {
+        imagesToFetch.push(url);
+        downloadUrls.push(defaultMapImageUrl(url, block));
+        return '';
+      },
+    })
+  );
+
+  await Promise.all(
+    imagesToFetch.map((url, i) => {
+      const fileName = getLocalFileName(url);
+
+      return !existingImages.has(fileName)
+        ? downloadImage(downloadUrls[i], path.join(STATIC_DIR, fileName))
+        : Promise.resolve();
+    })
+  );
+};
+
+export default fetchAndCacheImages;

--- a/site/src/notion/getPage.ts
+++ b/site/src/notion/getPage.ts
@@ -1,0 +1,17 @@
+import { NotionAPI } from 'notion-client';
+import type { BlockMapType } from 'react-notion';
+import fetchAndCacheImages from './fetchAndCacheImages';
+
+/**
+ * Fetch a Notion page object along with any referenced assets.
+ */
+const getPage = async (id: string) => {
+  const notion = new NotionAPI();
+  const page = await notion.getPage(id);
+
+  await fetchAndCacheImages(page.block as BlockMapType);
+
+  return page;
+};
+
+export default getPage;

--- a/site/src/pages/index.tsx
+++ b/site/src/pages/index.tsx
@@ -1,10 +1,10 @@
 import type { GetStaticProps } from 'next';
 import Head from 'next/head';
-import { NotionAPI } from 'notion-client';
 import type { BlockMapType } from 'react-notion';
 import { NotionRenderer } from 'react-notion';
 import Hero from '~components/Hero';
 import Layout from '~components/Layout';
+import getPage from '~notion/getPage';
 
 const BIO_PAGE_ID = '3c84a17f3b1347c1ac8677d7b0037b43';
 
@@ -13,11 +13,9 @@ type Props = {
 };
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
-  const notion = new NotionAPI();
-
   return {
     props: {
-      bio: (await notion.getPage(BIO_PAGE_ID)).block as BlockMapType,
+      bio: (await getPage(BIO_PAGE_ID)).block as BlockMapType,
     },
     revalidate: 10,
   };

--- a/site/src/pages/notes/[slug].tsx
+++ b/site/src/pages/notes/[slug].tsx
@@ -1,12 +1,12 @@
 import type { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
-import { NotionAPI } from 'notion-client';
 import type { BlockMapType } from 'react-notion';
-import { NotionRenderer } from 'react-notion';
 import ArticleHeader from '~components/ArticleHeader';
 import Container from '~components/Container';
 import Layout from '~components/Layout';
+import NotionRenderer from '~components/NotionRenderer';
 import getNotesPageMapping from '~notion/getNotesPageMapping';
+import getPage from '~notion/getPage';
 
 type Props = {
   title: string;
@@ -25,7 +25,6 @@ export const getStaticPaths: GetStaticPaths = async () => {
 
 export const getStaticProps: GetStaticProps<Props> = async context => {
   const { slug } = context.params;
-  const notion = new NotionAPI();
 
   const pages = await getNotesPageMapping();
   const { id, title, date } = pages['/notes/' + slug];
@@ -34,7 +33,7 @@ export const getStaticProps: GetStaticProps<Props> = async context => {
     props: {
       title,
       date,
-      blockMap: (await notion.getPage(id)).block as BlockMapType,
+      blockMap: (await getPage(id)).block as BlockMapType,
     },
     revalidate: 10,
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -423,6 +423,22 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
+"@types/react-dom@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.3.tgz#7fdf37b8af9d6d40127137865bb3fff8871d7ee1"
+  integrity sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "17.0.4"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.4.tgz#a67c6f7a460d2660e950d9ccc1c2f18525c28220"
+  integrity sha512-onz2BqScSFMoTRdJUZUDD/7xrusM8hBA2Fktk2qgaTYPCgPvWnDEgkrOs8hhPUf2jfcIXkJ5yK6VfYormJS3Jw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/react@^17.0.3":
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"


### PR DESCRIPTION
This adds server-side/build-time fetching of image files in Notion blocks so that they can be served from the site's CDN at `/static/` without hotlinking.

![image](https://user-images.githubusercontent.com/2547783/118354775-ad131c80-b564-11eb-8ab1-ae9c594dd682.png)

It looks like Notion's newly announced API isn't going to support this for a bit, so I am continuing development with the unofficial *notion-client* package.

![image](https://user-images.githubusercontent.com/2547783/118355018-be105d80-b565-11eb-94a4-d97448698273.png)
<https://developers.notion.com/reference/block>