### PR TITLE
Add custom CodeBlock component with copy button

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -21,6 +21,7 @@
     "lint": "eslint src/ --ext=.ts,.tsx"
   },
   "dependencies": {
+    "classnames": "^2.3.1",
     "date-fns": "^2.19.0",
     "flat-cache": "^3.0.4",
     "invariant": "^2.2.4",
@@ -31,12 +32,14 @@
     "prismjs": "^1.23.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",
+    "react-feather": "^2.0.9",
     "react-notion": "^0.9.3",
     "use-dark-mode": "^2.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",
     "@babel/register": "^7.13.8",
+    "@types/classnames": "^2.3.1",
     "@types/flat-cache": "^2.0.0",
     "@types/invariant": "^2.2.34",
     "@types/node": "^14.14.35",

--- a/site/src/components/CodeBlock.module.css
+++ b/site/src/components/CodeBlock.module.css
@@ -1,0 +1,33 @@
+.root {
+  position: relative;
+}
+
+.pre {
+  padding-right: 8em;
+}
+
+.copyButton {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  bottom: 1.2em;
+  right: 0.8em;
+  padding: 0.5em 1em;
+  border: 0;
+  outline: none;
+  background: var(--color-code-background);
+  font-family: var(--font-family-body);
+  color: inherit;
+  opacity: 0.8;
+  cursor: pointer;
+}
+
+.copyButton:hover {
+  opacity: 1;
+}
+
+.copyIcon {
+  width: 1.2em;
+  margin-right: 8px;
+  outline: var(--color-gruvbox-light1);
+}

--- a/site/src/components/CodeBlock.tsx
+++ b/site/src/components/CodeBlock.tsx
@@ -1,0 +1,70 @@
+import classNames from 'classnames';
+import { highlight, languages } from 'prismjs';
+import 'prismjs/components/prism-jsx';
+import { useCallback, useRef, useState } from 'react';
+import { Copy } from 'react-feather';
+import type { CustomBlockComponentProps } from 'react-notion';
+import useHasClipboard from '~hooks/useHasClipboard';
+import styles from './CodeBlock.module.css';
+
+type Props = {
+  code: string;
+  language: string;
+};
+
+const Code = ({ code, language }: Props) => {
+  const hasClipboard = useHasClipboard();
+  const codeRef = useRef<HTMLElement>();
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef(null);
+
+  const prismLanguage =
+    languages[language.toLowerCase()] || languages.javascript;
+  const langClass = `language-${language.toLowerCase()}`;
+
+  const handleClick = useCallback(async () => {
+    clearTimeout(timerRef.current);
+    await window.navigator.clipboard.writeText(codeRef.current?.textContent);
+    setCopied(true);
+    timerRef.current = setTimeout(() => setCopied(false), 1000);
+  }, []);
+
+  return (
+    <div className={classNames('notion-code-root', styles.root)}>
+      <pre className={classNames('notion-code', styles.pre, langClass)}>
+        {hasClipboard ? (
+          <button
+            className={styles.copyButton}
+            type="button"
+            onClick={handleClick}
+          >
+            <Copy className={styles.copyIcon} />
+            {copied ? 'Done!' : 'Copy'}
+          </button>
+        ) : null}
+        <code
+          ref={codeRef}
+          className={langClass}
+          dangerouslySetInnerHTML={{
+            __html: highlight(code, prismLanguage, language),
+          }}
+        />
+      </pre>
+    </div>
+  );
+};
+
+const CodeBlock = ({ blockValue }: CustomBlockComponentProps<'code'>) => {
+  if (blockValue.properties.title) {
+    const content = blockValue.properties.title[0][0];
+    const language = blockValue.properties.language[0][0];
+
+    return (
+      <Code key={blockValue.id} language={language ?? ''} code={content} />
+    );
+  }
+
+  return null;
+};
+
+export default CodeBlock;

--- a/site/src/components/NotionRenderer.tsx
+++ b/site/src/components/NotionRenderer.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from 'react';
 import { NotionRenderer as BaseNotionRenderer } from 'react-notion';
+import CodeBlock from './CodeBlock';
 
 const mapImageUrl = (url: string) => {
   const imagePath = url.split('amazonaws.com/secure.notion-static.com/')[1];
@@ -7,8 +8,18 @@ const mapImageUrl = (url: string) => {
   return `/static/${imagePath.substring(0, 36)}.${imagePath.split('.')[1]}`;
 };
 
-const NotionRenderer = (props: ComponentProps<typeof BaseNotionRenderer>) => (
-  <BaseNotionRenderer {...props} mapImageUrl={mapImageUrl} />
+const NotionRenderer = ({
+  customBlockComponents,
+  ...props
+}: ComponentProps<typeof BaseNotionRenderer>) => (
+  <BaseNotionRenderer
+    {...props}
+    mapImageUrl={mapImageUrl}
+    customBlockComponents={{
+      ...customBlockComponents,
+      code: CodeBlock,
+    }}
+  />
 );
 
 export default NotionRenderer;

--- a/site/src/hooks/useHasClipboard.ts
+++ b/site/src/hooks/useHasClipboard.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * A hook returning whether the browser has access to the Clipboard API.
+ */
+const useHasClipboard = () => {
+  const [hasClipboard, setHasClipboard] = useState(false);
+
+  useEffect(() => setHasClipboard('clipboard' in window.navigator), []);
+
+  return hasClipboard;
+};
+
+export default useHasClipboard;

--- a/site/src/styles/notion.css
+++ b/site/src/styles/notion.css
@@ -88,8 +88,12 @@
   }
 }
 
-.notion-code {
+.notion-code-root {
   margin: 2em 0;
+}
+
+.notion-code {
+  margin: 0;
   padding: 1.75em 1.5em;
   border-radius: 6px;
   font-size: 75% !important;

--- a/site/src/styles/prism-gruvbox-dark.css
+++ b/site/src/styles/prism-gruvbox-dark.css
@@ -28,7 +28,7 @@ pre[class*='language-'] {
 
 :not(pre) > code[class*='language-'],
 pre[class*='language-'] {
-  background: var(--color-gruvbox-dark0-soft);
+  background: var(--color-code-background);
 }
 
 .token.comment,

--- a/site/src/styles/theme.css
+++ b/site/src/styles/theme.css
@@ -25,6 +25,7 @@
   --color-header: rgba(255, 255, 255, 0.95);
   --color-text-primary: #37352f;
   --color-text-secondary: #b3b3b3;
+  --color-code-background: var(--color-gruvbox-dark0-soft);
   --color-inline-code: var(--color-gruvbox-bright-red);
   --color-divider: var(--color-grey-lightest);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,6 +373,13 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
+"@types/classnames@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.3.1.tgz#3c2467aa0f1a93f1f021e3b9bcf938bd5dfdc0dd"
+  integrity sha512-zeOWb0JGBoVmlQoznvqXbE0tEC/HONsnoUNH19Hc96NFsTAwTXbTqb8FMYkru1F/iqp7a18Ws3nWJvtA1sHD1A==
+  dependencies:
+    classnames "*"
+
 "@types/eslint@^7.2.7":
   version "7.2.7"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.7.tgz#f7ef1cf0dceab0ae6f9a976a0a9af14ab1baca26"
@@ -985,6 +992,11 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+classnames@*, classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
 classnames@2.2.6:
   version "2.2.6"
@@ -3252,6 +3264,13 @@ react-dom@17.0.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.1"
+
+react-feather@^2.0.9:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/react-feather/-/react-feather-2.0.9.tgz#6e42072130d2fa9a09d4476b0e61b0ed17814480"
+  integrity sha512-yMfCGRkZdXwIs23Zw/zIWCJO3m3tlaUvtHiXlW+3FH7cIT6fiK1iJ7RJWugXq7Fso8ZaQyUm92/GOOHXvkiVUw==
+  dependencies:
+    prop-types "^15.7.2"
 
 react-is@16.13.1, react-is@^16.8.1:
   version "16.13.1"


### PR DESCRIPTION
Replaces code block provided by react-notion with a custom component. Identical base appearance to before, but now includes copying functionality.

|Mobile|Desktop|
|-|-|
|![image](https://user-images.githubusercontent.com/2547783/118356726-9245a580-b56e-11eb-800c-25032b125307.png)|![image](https://user-images.githubusercontent.com/2547783/118356738-9e316780-b56e-11eb-80ad-6aa4656bb705.png)|
|![image](https://user-images.githubusercontent.com/2547783/118356766-b3a69180-b56e-11eb-90b6-2bfb9e9e8887.png)|![image](https://user-images.githubusercontent.com/2547783/118356744-a2f61b80-b56e-11eb-8b3d-79c61bcd7a3a.png)|