### PR TITLE
Update code highlighting to handle JSX and plain text

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -43,6 +43,7 @@
     "@types/flat-cache": "^2.0.0",
     "@types/invariant": "^2.2.34",
     "@types/node": "^14.14.35",
+    "@types/prismjs": "^1.16.5",
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.3",
     "babel-loader": "^8.2.2",

--- a/site/src/components/CodeBlock.module.css
+++ b/site/src/components/CodeBlock.module.css
@@ -2,7 +2,7 @@
   position: relative;
 }
 
-.pre {
+.content {
   padding-right: 8em;
 }
 

--- a/site/src/pages/_app.tsx
+++ b/site/src/pages/_app.tsx
@@ -13,10 +13,11 @@ import 'prismjs';
 import 'prismjs/components/prism-markup-templating';
 import 'prismjs/components/prism-bash';
 import 'prismjs/components/prism-css';
-import 'prismjs/components/prism-javascript';
 import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-php';
 import 'prismjs/components/prism-python';
+import 'prismjs/components/prism-typescript';
 
 const App = ({ Component, pageProps }: AppProps) => {
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -425,6 +425,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
   integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
 
+"@types/prismjs@^1.16.5":
+  version "1.16.5"
+  resolved "https://registry.yarnpkg.com/@types/prismjs/-/prismjs-1.16.5.tgz#378f491ff02304ce50924b05283111d4a286ecba"
+  integrity sha512-nSU7U6FQDJJCraFNwaHmH5YDsd/VA9rTnJ7B7AGFdn+m+VSt3FjLWN7+AbqxZ67dbFazqtrDFUto3HK4ljrHIg==
+
 "@types/prop-types@*":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"


### PR DESCRIPTION
- Remove default `javascript` language selection and highlighting for plain text/unrecognised languages.
- Add override from `javascript` to `jsx`, since Notion doesn't yet support specifying JSX.