### PR TITLE
Adjust project config for Vercel deployments

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 15.x
+          node-version: 14.x
 
       - name: Install dependencies
         run: yarn --frozen-lockfile

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   i18n: {
     locales: ['en-GB'],
     defaultLocale: 'en-GB',

--- a/site/package.json
+++ b/site/package.json
@@ -11,7 +11,7 @@
     "directory": "site"
   },
   "engines": {
-    "node": "^15.12.0"
+    "node": "14.x"
   },
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- Reduce Node.js version requirement (wide `14.x` version specifier used to appease Vercel).
- Disable ESLint runs during builds.