### PR TITLE
Fix static dir resolution on build

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -8,7 +8,7 @@
 
 # Build output
 /.cache
-/public/static/
+/public/static/*
 !/public/static/.gitkeep
 
 # Cache and log files

--- a/site/src/notion/fetchAndCacheImages.ts
+++ b/site/src/notion/fetchAndCacheImages.ts
@@ -7,7 +7,7 @@ import ReactDOMServer from 'react-dom/server';
 import type { BlockMapType } from 'react-notion';
 import { defaultMapImageUrl, NotionRenderer } from 'react-notion';
 
-const STATIC_DIR = './public/static';
+const STATIC_DIR = path.join(process.cwd(), 'public/static');
 
 const getLocalFileName = (url: string) => {
   const imagePath = url.split('amazonaws.com/secure.notion-static.com/')[1];


### PR DESCRIPTION
- Fix resolution of `STATIC_DIR` in `fetchAndCacheImages`, which was only working under `yarn dev`.
- Fix `.gitignore` specifier to include `public/static/.gitkeep`.
